### PR TITLE
Habilitando e utilizando o JWT

### DIFF
--- a/Conspiracao.API/Program.cs
+++ b/Conspiracao.API/Program.cs
@@ -12,7 +12,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddInfrastructureSwagger();
+//builder.Services.AddSwaggerGen();
 
 
 builder.Services.AddInfraStructure(builder.Configuration);

--- a/Conspiracao.Infra.IoC/Conspiracao.Infra.IoC.csproj
+++ b/Conspiracao.Infra.IoC/Conspiracao.Infra.IoC.csproj
@@ -9,6 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Conspiracao.Infra.IoC/DependencyInjectionSwagger.cs
+++ b/Conspiracao.Infra.IoC/DependencyInjectionSwagger.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Conspiracao.Infra.IoC
+{
+    public static class DependencyInjectionSwagger
+    {
+        public static IServiceCollection AddInfrastructureSwagger(this IServiceCollection services)
+        {
+            services.AddSwaggerGen(c =>
+            {
+                c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme()
+                {
+                    Name = "Autorization",
+                    Type = SecuritySchemeType.ApiKey,
+                    BearerFormat = "JWT",
+                    In = ParameterLocation.Header,
+                    Description = "Json Web Token (JWT) is an open standard RFC (7519) that defines a compact and self-contained way for securely transmitting information between parties as a JSON object.",
+                });
+
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement(){
+                {
+                    new OpenApiSecurityScheme()
+                    {
+                        Reference = new OpenApiReference()
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        }
+                    },
+                    new string[] { }
+                    }
+            });
+
+            });
+
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
Habilitando o JWT para ser utilizado na aplicação, para isso foi incluso na camada Infra.IoC uma classe para injetar essa  funcionalidade e utilizada na camada de API no Program.cs